### PR TITLE
update tool versions and fix tenant name variable in login script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/nodejs:18.20.3-
         LANG=en_US.UTF-8 \
         # set a fixed location for the Module analysis cache
         PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-${ARCH}-Mariner-2
+        POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-${ARCH}-Mariner-2 \
+        PNPPOWERSHELL_UPDATECHECK=false
 
     # Copy only the files we need from the previous stage
     COPY --from=installer-env ["/opt/microsoft/powershell", "/opt/microsoft/powershell"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS ins
 
     # Define Args for the needed to add the package
     ARG ARCH=amd64 \
-        PS_VERSION=7.4.6 \
+        PS_VERSION=7.5.2 \
         PS_INSTALL_VERSION=7 \
         PS_PACKAGE_URL_BASE64
 
@@ -20,28 +20,29 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS ins
         tdnf update -y \
         && tdnf install -y ca-certificates tar
 
-    RUN if [[ "${ARCH}" == "arm64" ]]; then \
-            curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm64.tar.gz -o /tmp/powershell.tar.gz \
-            && pwsh_sha256='c0159b03e85f44ae1e7697818a011558da6c813d0aae848bf5ac13bf435d8624' \
+    RUN if [[ "${ARCH}" == "amd64" ]]; then \
+            curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-amd64.tar.gz -o /tmp/powershell.tar.gz \
+            && pwsh_sha256='d4d2c55628755f5cd8b2609ad7117c1eada0aa0086f195d48131ee482ef7d71a' \
             && echo "$pwsh_sha256  /tmp/powershell.tar.gz" | sha256sum -c - ; \
         else \
             curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
-            && pwsh_sha256='6f6015203c47806c5cc444c19d8ed019695e610fbd948154264bf9ca8e157561' \
+            && pwsh_sha256='8fa9584f6f95d29ca1466c4397ac39c371373d6581c12dfae9ebd53c06d77664' \
             && echo "$pwsh_sha256  /tmp/powershell.tar.gz" | sha256sum -c - ; \
         fi && \
         tar zxf /tmp/powershell.tar.gz -C ${PS_INSTALL_FOLDER}
 
-FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/nodejs:18.20.3-1-cm2.0.20240731-${ARCH} AS final-image
+FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS final-image
 
     # Define Args and Env needed to create links
     ARG ARCH=amd64 \
     PS_INSTALL_VERSION=7 \
-    PS_VERSION=7.4.6 \
-    SPFX_VERSION=1.18.2 \
-    YEOMAN_VERSION=5.0.0 \
-    M365CLI_VERSION=10.0.0 \
-    PNP_VERSION=2.12.0 \
-    AZ_VERSION=12.4.0
+    PS_VERSION=7.5.2 \
+    SPFX_VERSION=1.21.1 \
+    YEOMAN_VERSION=5.1.0 \
+    M365CLI_VERSION=10.9.0 \
+    PNP_VERSION=3.1.0 \
+    AZ_VERSION=14.2.0 \
+    NODE_VERSION=22.15.0
 
     ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
         \
@@ -62,6 +63,14 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/nodejs:18.20.3-
         && tdnf install -y icu less openssh-clients ca-certificates git dotnet-runtime-7.0 tar awk shadow-utils terraform azure-cli \
         && tdnf upgrade -y \
         && tdnf clean all
+
+    RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz -o /tmp/node.tar.xz \
+        && mkdir -p /usr/local/lib/nodejs \
+        && tar -xJf /tmp/node.tar.xz -C /usr/local/lib/nodejs \
+        && ln -s /usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-${ARCH}/bin/node /usr/bin/node \
+        && ln -s /usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-${ARCH}/bin/npm /usr/bin/npm \
+        && ln -s /usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-${ARCH}/bin/npx /usr/bin/npx \
+        && node --version && npm --version
 
     # # Install NPM Tooling
     RUN npm install gulp-cli yo@${YEOMAN_VERSION} @microsoft/generator-sharepoint@${SPFX_VERSION} @pnp/cli-microsoft365@${M365CLI_VERSION} --global

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS ins
 
     # Define Args for the needed to add the package
     ARG ARCH=amd64 \
-        PS_VERSION=7.4.5 \
+        PS_VERSION=7.4.6 \
         PS_INSTALL_VERSION=7 \
         PS_PACKAGE_URL_BASE64
 
@@ -22,11 +22,11 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/core:2.0 AS ins
 
     RUN if [[ "${ARCH}" == "arm64" ]]; then \
             curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm64.tar.gz -o /tmp/powershell.tar.gz \
-            && pwsh_sha256='f0968649ecd47d5500ccb766c4ff4da34e0d78254cce9098c7f42d0e5484b513' \
+            && pwsh_sha256='c0159b03e85f44ae1e7697818a011558da6c813d0aae848bf5ac13bf435d8624' \
             && echo "$pwsh_sha256  /tmp/powershell.tar.gz" | sha256sum -c - ; \
         else \
             curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-x64.tar.gz -o /tmp/powershell.tar.gz \
-            && pwsh_sha256='c23509cc4d08c62b9ff6ea26f579ee4c50f978aa34269334a85eda2fec36f45b' \
+            && pwsh_sha256='6f6015203c47806c5cc444c19d8ed019695e610fbd948154264bf9ca8e157561' \
             && echo "$pwsh_sha256  /tmp/powershell.tar.gz" | sha256sum -c - ; \
         fi && \
         tar zxf /tmp/powershell.tar.gz -C ${PS_INSTALL_FOLDER}
@@ -36,12 +36,12 @@ FROM --platform=linux/${ARCH} mcr.microsoft.com/cbl-mariner/base/nodejs:18.20.3-
     # Define Args and Env needed to create links
     ARG ARCH=amd64 \
     PS_INSTALL_VERSION=7 \
-    PS_VERSION=7.4.5 \
+    PS_VERSION=7.4.6 \
     SPFX_VERSION=1.18.2 \
     YEOMAN_VERSION=5.0.0 \
-    M365CLI_VERSION=7.3.0 \
+    M365CLI_VERSION=10.0.0 \
     PNP_VERSION=2.12.0 \
-    AZ_VERSION=12.2.0
+    AZ_VERSION=12.4.0
 
     ENV PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
         \

--- a/scripts/login.psm1
+++ b/scripts/login.psm1
@@ -133,7 +133,7 @@ switch ($global:loginSelector) {
             grant_type    = "client_credentials"
             client_id     = $global:appId
             client_secret = $global:appSecret
-            resource      = "https://$($global:M365_TENANT_NAME).sharepoint.com/"
+            resource      = "https://$($global:M365_TENANTNAME).sharepoint.com/"
         }
         $response = Invoke-RestMethod -Uri $tokenEndpoint -Method Post -Body $body
         $global:PnPCreds = @{


### PR DESCRIPTION
This pull request updates the `Dockerfile` and a script to modernize the container environment and fix a variable name in the login script. The main changes include updating PowerShell and several Node.js-based tool versions, switching the base image, adding Node.js installation steps, and correcting a variable reference in the PowerShell login script.

**Container environment modernization:**

* Upgraded PowerShell from version `7.4.5` to `7.5.2`, along with updated SHA256 checksums for the new release. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L9-R9) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R45)
* Updated versions for key tools: SPFx (`1.18.2` → `1.21.1`), Yeoman (`5.0.0` → `5.1.0`), M365 CLI (`7.3.0` → `10.9.0`), PnP (`2.12.0` → `3.1.0`), and Azure CLI (`12.2.0` → `14.2.0`).
* Switched the final image base from a Node.js image to a plain Mariner core image, and added explicit installation of Node.js `22.15.0` (including symlinks for `node`, `npm`, and `npx`). [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R45) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R67-R74)
* Set `PNPPOWERSHELL_UPDATECHECK=false` in the environment to suppress update checks for PnP PowerShell.

**Script bugfix:**

* Fixed a typo in the login script by changing `$global:M365_TENANT_NAME` to `$global:M365_TENANTNAME` for correct variable usage.